### PR TITLE
Replaced `boost::` type pointers by `std::`.

### DIFF
--- a/baxter_simulator/baxter_sim_kinematics/src/arm_kinematics.cpp
+++ b/baxter_simulator/baxter_sim_kinematics/src/arm_kinematics.cpp
@@ -264,8 +264,8 @@ bool Kinematics::loadModel(const std::string xml)
 bool Kinematics::readJoints(urdf::Model& robot_model)
 {
   num_joints = 0;
-  boost::shared_ptr<const urdf::Link> link = robot_model.getLink(tip_name);
-  boost::shared_ptr<const urdf::Joint> joint;
+  std::shared_ptr<const urdf::Link> link = robot_model.getLink(tip_name);
+  std::shared_ptr<const urdf::Joint> joint;
   for (int i = 0; i < chain.getNrOfSegments(); i++)
     while (link && link->name != root_name)
     {


### PR DESCRIPTION
Addressed multiple errors on operator assignments and similar stating "no known conversion" in: conversion from ‘urdf::LinkConstSharedPtr’ {aka ‘std::shared_ptr<const urdf::Link>’} to non-scalar type ‘boost::shared_ptr<const urdf::Link>’ requested